### PR TITLE
Add .gitignore for Python, Vercel, and local development artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Python cache and bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Python virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Packaging artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Test and coverage outputs
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+
+# Type checker and linter caches
+.mypy_cache/
+.ruff_cache/
+.pyre/
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Logs
+*.log
+
+# macOS and Windows system files
+.DS_Store
+Thumbs.db
+
+# IDE/editor settings
+.vscode/
+.idea/
+
+# Node.js dependencies (if used for local tooling)
+node_modules/
+
+# Vercel local settings
+.vercel/


### PR DESCRIPTION
### Motivation
- Provide a repository-level `.gitignore` to avoid committing common local and build artifacts for Python, Node tooling, and Vercel deployments.

### Description
- Add a new top-level `.gitignore` that ignores Python cache/bytecode and virtual environments, packaging outputs, test/coverage and type-checker/linter caches, environment files and logs, OS/editor files, `node_modules/`, and local `.vercel/` settings.

### Testing
- Verified the `.gitignore` file exists at the repository root and inspected its contents with `nl -ba .gitignore`; no runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a81f7261648331bd13a7f2e103c3c3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project configuration files to standardize development environment setup for Python, Node.js, and deployment tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->